### PR TITLE
ci: add ci and test package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [3.9]
+        os: [ubuntu-20.04]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools \
+            git+https://github.com/colcon/colcon-core \
+            git+https://github.com/colcon/colcon-library-path \
+            pytest flake8 pydocstyle
+      - name: Build colcon
+        run: |
+          colcon build --paths ./*
+      - name: Test with pytest
+        run: |
+          pytest
+      - name: Build test package
+        run: |
+          source install/setup.sh
+          # We need to specify the location because it is inside a package.
+          colcon build --paths colcon-dub/test/dub-test-package

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+colcon_d
+=============
+
+[![CI](https://github.com/nonanonno/colcon_d/actions/workflows/ci.yml/badge.svg)](https://github.com/nonanonno/colcon_d/actions/workflows/ci.yml)
+
+Extensions for [colcon-core](https://github.com/colcon/colcon-core) to support [DUB](https://dub.pm/index.html) and combination of DUB and ROS2.
+
+- [colcon-dub](colcon-dub) : An extension to support DUB
+- colcon-ros-dub : An extension to support combination of DUB and ROS2 (TBI)

--- a/colcon-dub/test/dub-test-package/dub.json
+++ b/colcon-dub/test/dub-test-package/dub.json
@@ -1,0 +1,9 @@
+{
+	"authors": [
+		"nonanonno"
+	],
+	"copyright": "Copyright © 2021, nonanonno",
+	"description": "test package",
+	"license": "Apache-2.0",
+	"name": "dub-test-package"
+}

--- a/colcon-dub/test/dub-test-package/source/app.d
+++ b/colcon-dub/test/dub-test-package/source/app.d
@@ -1,0 +1,5 @@
+import std.stdio;
+
+void main() {
+  writeln("Edit source/app.d to start your project.");
+}

--- a/colcon-dub/test/test_flake8.py
+++ b/colcon-dub/test/test_flake8.py
@@ -40,7 +40,6 @@ def test_flake8():
     sys.stdout = sys.stderr
     # implicitly calls report_errors()
     report = style_guide.check_files([
-        str(Path(__file__).parents[1] / 'bin' / 'colcon'),
         str(Path(__file__).parents[1] / 'colcon_dub'),
     ])
     report_tests = style_guide_tests.check_files([


### PR DESCRIPTION
This PR sets up CI to check if the extensions can be built.

Note that we cannot get some errors inside the extension as status code. i.e. exception at package identification is cared inside colcon system this error doesn't appear as status code of `colcon build`. So we will check errors by executing some dub package when we implement build task for dub.