### PR TITLE
Feat/colcon dub test task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,13 @@ jobs:
           compiler: ${{ matrix.dc }}
       - name: Install dependencies
         run: |
+          # colcon-output is required to collect summary
           python -m pip install --upgrade pip
           python -m pip install setuptools \
             git+https://github.com/colcon/colcon-core \
             git+https://github.com/colcon/colcon-library-path \
             git+https://github.com/colcon/colcon-ros \
+            git+https://github.com/colcon/colcon-output.git \
             pytest pytest-shell flake8 pydocstyle
       - name: Build colcon
         run: |

--- a/colcon-dub/README.md
+++ b/colcon-dub/README.md
@@ -11,5 +11,5 @@ Since DUB doesn't have function to get location of dependent package as environm
 
 - [x] Support package identify
 - [x] Support build task
-- [ ] Support test task
+- [x] Support test task
 - [x] Support handling package dependencies

--- a/colcon-dub/colcon_dub/task/dub/build.py
+++ b/colcon-dub/colcon_dub/task/dub/build.py
@@ -99,6 +99,7 @@ class DubBuildTask(TaskExtensionPoint):
             cmd = [DUB_EXECUTABLE, 'build']
             if target['name'] is not None:
                 cmd += ['-c', target['name']]
+            cmd += ['--']
             cmd += (self.context.args.dub_args or [])
 
             completed = await run(self.context, cmd, cwd=args.path, env=env)

--- a/colcon-dub/colcon_dub/task/dub/test.py
+++ b/colcon-dub/colcon_dub/task/dub/test.py
@@ -1,0 +1,72 @@
+# Copyright 2021 nonanonno
+# Licensed under the Apache License, Version 2.0
+"""Implement test task for DUB package."""
+
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Dict, Optional
+
+from colcon_dub.dub import DUB_EXECUTABLE
+from colcon_dub.dub import DubPackage
+
+from colcon_core.logging import colcon_logger
+from colcon_core.task import TaskExtensionPoint
+from colcon_core.task import run
+from colcon_core.plugin_system import satisfies_version
+from colcon_core.shell import get_command_environment
+
+logger = colcon_logger.getChild(__name__)
+
+
+class DubTestTask(TaskExtensionPoint):
+    """Test dub package."""
+
+    def __init__(self):
+        super().__init__()
+        satisfies_version(TaskExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser: ArgumentParser):  # noqa: D102
+        parser.add_argument(
+            '--dub-args',
+            nargs='*', metavar='*', type=str.lstrip,
+            help='Pass arguments to DUB projects. '
+            'Arguments matching other options must be prefixed by a space,\n'
+            'e.g. --dub-args " --help"')
+
+    async def test(
+        self, *, additional_hooks=None) -> Optional[int]:  # noqa D102
+        pkg = self.context.pkg
+        args = self.context.args  # TestPackageArguments
+
+        logger.info(
+            "Testing DUB package in '{args.path}'".format_map(
+                locals()))
+
+        try:
+            env = await get_command_environment(
+                'test', args.build_base, self.context.dependencies)
+        except RuntimeError as e:
+            logger.error(str(e))
+            return 1
+
+        dub_package = DubPackage(Path(args.path))
+
+        rc = await self._test(dub_package, env)
+        if rc:
+            return rc
+
+    async def _test(self, dub: DubPackage, env: Dict) -> Optional[int]:
+        self.progress('test')
+
+        if DUB_EXECUTABLE is None:
+            raise RuntimeError("Could not find 'dub' executable")
+
+        args = self.context.args  # TestPackageArguments
+
+        cmd = [DUB_EXECUTABLE, 'test']
+        cmd += ['--']
+        cmd += (self.context.args.dub_args or [])
+
+        completed = await run(self.context, cmd, cwd=args.path, env=env)
+        if completed.returncode:
+            return completed.returncode

--- a/colcon-dub/setup.cfg
+++ b/colcon-dub/setup.cfg
@@ -37,6 +37,7 @@ colcon_core.package_identification =
     dub = colcon_dub.package_identification.dub:DubPackageIdentification
 colcon_core.task.build =
     dub = colcon_dub.task.dub.build:DubBuildTask
-
+colcon_core.task.test =
+    dub = colcon_dub.task.dub.test:DubTestTask
 [flake8]
 import-order-style = google

--- a/colcon-dub/test/dub_test_package/.gitignore
+++ b/colcon-dub/test/dub_test_package/.gitignore
@@ -6,7 +6,7 @@ docs/
 dub_test_package.so
 dub_test_package.dylib
 dub_test_package.dll
-dub_test_package.a
+libdub_test_package.a
 dub_test_package.lib
 dub_test_package-test-*
 *.exe

--- a/colcon-dub/test/dub_test_package/dub.json
+++ b/colcon-dub/test/dub_test_package/dub.json
@@ -5,5 +5,18 @@
 	"copyright": "Copyright © 2021, nonanonno",
 	"description": "test package",
 	"license": "Apache-2.0",
-	"name": "dub_test_package"
+	"name": "dub_test_package",
+	"configurations": [
+		{
+			"name": "dub_test_package",
+			"targetType": "executable"
+		},
+		{
+			"name": "unittest",
+			"targetType": "library"
+		}
+	],
+	"dependencies": {
+		"silly": "~>1.1.1"
+	}
 }

--- a/colcon-dub/test/dub_test_package/dub.selections.json
+++ b/colcon-dub/test/dub_test_package/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"silly": "1.1.1"
+	}
+}

--- a/colcon-dub/test/dub_test_package/source/app.d
+++ b/colcon-dub/test/dub_test_package/source/app.d
@@ -1,5 +1,25 @@
 import std.stdio;
 
-void main() {
-  writeln("Hello, World!");
+version (unittest)
+{
+
+}
+else
+{
+  void main()
+  {
+    writeln("Hello, World!");
+  }
+}
+
+@("success")
+unittest
+{
+  assert(true);
+}
+
+@("fail")
+unittest
+{
+  assert(false);
 }

--- a/colcon-dub/test/test_dub.py
+++ b/colcon-dub/test/test_dub.py
@@ -25,6 +25,7 @@ def _search_workspace(upper_than=2) -> Optional[str]:
 
 
 WORKSPACE_ROOT = _search_workspace()
+PATH_TO_THIS = str(Path(__file__).absolute().parent)
 
 
 def test_dub_package_execute(bash: pytest_shell.shell.bash):
@@ -33,3 +34,23 @@ def test_dub_package_execute(bash: pytest_shell.shell.bash):
     assert bash.run_script_inline([
         './install/dub_test_package/lib/dub/dub_test_package/dub_test_package'
     ]) == 'Hello, World!'
+
+
+def test_colcon_test_success(bash: pytest_shell.shell.bash):
+    """Check if the dub package can be tested via colcon test."""
+    bash.cd(WORKSPACE_ROOT)
+    assert bash.run_script_inline([
+        'source install/setup.sh',
+        f'colcon test --paths {PATH_TO_THIS}/* --dub-args -i success'
+    ]).count('Summary: 1 package finished') > 0
+
+
+def test_colcon_test_fail(bash: pytest_shell.shell.bash):
+    """Check if the dub package can be tested via colcon test."""
+    bash.cd(WORKSPACE_ROOT)
+    bash.auto_return_code_error = False
+    bash.run_script_inline([
+        'source install/setup.sh',
+        f'colcon test --paths {PATH_TO_THIS}/* --dub-args -i fail'
+    ])
+    assert bash.last_return_code != 0


### PR DESCRIPTION
This implements test task for dub packages by calling `dub test`.
Note that test task doesn't handle `DUB_PACKAGE_PATH` so build task must be done before testing (same as other build system). But sometimes test task can success because `dub test` doesn't require `dub build`.